### PR TITLE
Feature/research reminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ The fields in Airtable should be configured as per [this example](https://airtab
 - Once the CF has looked over the application, and wishes to invite the applicant to a workshop, they should tick the `send_invitation` checkbox in Airtable. This will trigger the server to create a new issue in tech-for-better-leads with the initial labels added and send an invitation to the applicant with a link to workshops and a link to the PO agreement (note: the server is currently configured to run once every 30 minutes, so there may be a delay of up to 30 minutes before the new issues appear)
 - If the client has not booked into a workshop, the CF can send a reminder by checking the `send_invitation_reminder` checkbox in Airtable.
 - After the client has attended workshop 1, you can tick the `attended_workshop_1` checkbox, which will send out an email with an individualised link for the follow-up user research survey and update the labels on Github.
-- When the user research survey is received back, the contents of the survey will be automatically added to the existing issue and the labels will be updated.
+- If the client hasn't yet returned their user survey results, then `follow_up_survey_received` will be unchecked. In order to nudge the client, check `send_survey_reminder` in Airtable. This will send out a reminder email, and `sent_survey_reminder` will be checked once that email is actually sent (could take up to 30 mins).
+- When the user research survey is received back, `follow_up_survey_received` will be checked in Airtable, the contents of the survey will be automatically added to the existing issue, and the labels will be updated.
 - If `project_completed` is checked in Airtable, then feel free to check `send_exit_feedback`. This will send out the participant feedback form to the client, and `sent_exit_feedback` will also be ticked when that email is actually sent (it may take up to 30 mins).
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Configuration is set through environment variables. The following must be set in
 
 ### Airtable Setup
 
-The fields in Airtable should be configured as per [this example](https://airtable.com/shrPz9lEEo5PheVna)
+The fields in Airtable should be configured as per [this example](https://airtable.com/invite/l?inviteId=invjFabwJZfMFqaxf&inviteToken=79d712b468354a15d8bfc298eec154bf9bc9adc76fb59d8050617c5425563b35). Ask @charlielafosse if there are problems with access.
 
 ## Running locally
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ It can:
 - Send an invitation to attend a workshop, with a link to a given page (e.g. Eventbrite)
 - Send a reminder invitation if a client has not yet booked themselves in
 - Create a new issue in tech-for-better-leads, add the application info and initial labels
-- Send individual emails to Tech for Better clients with user research survey links, and also feedback forms once a project has been completed
+- Send individual emails to Tech for Better clients with user research survey links, as well as a reminder email if need
+- Send feedback forms once a project has been completed
 - Look for user research surveys in the airtable base, add them to the relevant issue in tech-for-better-leads and update the labels
 
 It could potentially do even more!
@@ -53,6 +54,7 @@ Configuration is set through environment variables. The following must be set in
 - LINKS_PO_AGREEMENT=https://docs.google.com/document/d/1PA6i2VILi4kJOF7QuJxHMwTX2dILNI2BxCBfmZ0ARHs/edit?usp=sharing
 - LINKS_RESEARCH_SURVEY_URL=YOURSURVEYLINK // URL to the follow up survey
 - LINKS_EXIT_FEEDBACK_FORM_URL=YOURFEEDBACKFORMLINK // URL to the exit feedback form
+- USER_RESEARCH_DEADLINE=YOURDATE // The current deadline for POs to return their user research results. Make sure it's formatted like so: 22nd-April
 
 ### Airtable Setup
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1186,7 +1186,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -1601,7 +1602,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -1657,6 +1659,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -1700,12 +1703,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -2891,7 +2896,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3356,7 +3362,8 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3420,6 +3427,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3468,13 +3476,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/config.js
+++ b/src/config.js
@@ -52,6 +52,12 @@ if (!exitFeedbackFormUrl)
     "LINKS_EXIT_FEEDBACK_FORM_URL must be set to the URL for the Airtable exit feedback form"
   );
 
+const userResearchDeadline = process.env.USER_RESEARCH_DEADLINE
+ ? process.env.USER_RESEARCH_DEADLINE
+ : false;
+if(!userResearchDeadline)
+  throw new Error("USER_RESEARCH_DEADLINE must be set to the current deadline for returning the results of the user research survey");
+
 let pass;
 if (process.env.EMAIL_PASSWORD) {
   pass = process.env.EMAIL_PASSWORD;
@@ -115,6 +121,9 @@ module.exports = {
   airtable: {
     baseId,
     apiKey
+  },
+  dates: {
+    userResearchDeadline
   },
   email: {
     user,

--- a/src/controllers/checkRecords.js
+++ b/src/controllers/checkRecords.js
@@ -11,7 +11,8 @@ const {
   sendClientInvitationReminder,
   sendFollowUpSurvey,
   sendClientSurveyNotification,
-  sendExitFeedbackForm
+  sendExitFeedbackForm,
+  sendSurveyReminder
 } = require("../models/email/index");
 
 const {
@@ -61,6 +62,12 @@ const checkRecords = (req, res, next) => {
   querySurveysByFormula(newSurvey)
     .then(addSurveyToIssue)
     .catch(console.error);
+
+  // Airtable formula to check if send_survey_reminder has been checked, but a reminder to submit user research hasn't been sent
+  const needsSurveyReminder = "AND({send_survey_reminder} = 1, {sent_survey_reminder} = 0)";
+  queryApplicationsByFormula(needsSurveyReminder)
+    .then(sendSurveyReminderEmail)
+    .catch(console.error)
 
   // Airtable formula for checking if send_exit_feedback has been checked, but no exit feedback form has been sent
   const needsExitFeedback =
@@ -123,6 +130,12 @@ const addSurveyToIssue = records => {
     });
   }
 };
+
+const sendSurveyReminderEmail = records => {
+  records.forEach(record => {
+    sendSurveyReminder(record);
+  });
+}
 
 const sendClientExitFeedbackForm = records => {
   records.forEach(record => {

--- a/src/models/email/index.js
+++ b/src/models/email/index.js
@@ -5,6 +5,7 @@ const sendClientInvitationReminder = require("./sendClientInvitationReminder");
 const sendFollowUpSurvey = require("./sendFollowUpSurvey");
 const sendClientSurveyNotification = require("./sendClientSurveyNotification");
 const sendExitFeedbackForm = require("./sendExitFeedbackForm");
+const sendSurveyReminder = require("./sendSurveyReminder")
 
 module.exports = {
   sendCFNotification,
@@ -13,5 +14,6 @@ module.exports = {
   sendClientInvitationReminder,
   sendFollowUpSurvey,
   sendClientSurveyNotification,
-  sendExitFeedbackForm
+  sendExitFeedbackForm,
+  sendSurveyReminder
 };

--- a/src/models/email/sendSurveyReminder.js
+++ b/src/models/email/sendSurveyReminder.js
@@ -1,14 +1,24 @@
 const {
-  email: { user, name }
+  email: { user, name },
+  dates: { userResearchDeadline },
+  links: { researchSurveyUrl }
 } = require("../../config");
 
 const transporter = require("./transporter");
 
 const sendSurveyReminder = record => {
-  const subject = "User Research reminder";
+  const subject = "Tech for Better user research reminder";
   const html = `
-  <p>Hi,</p>
-  <p>TESTING THIS WORKS!!! HE he</p>
+  <p>Hi there,</p>
+  <p>Just a gentle reminder that the deadline for returning the results of your user research is ${userResearchDeadline
+    .split("-")
+    .join(" ")}. In order for your project to be up for selection by the London cohort, we'll need the results back before that date.</p>
+  <p>Here's the <a href="${researchSurveyUrl}?prefill_Email=${
+    record.fields["Email"]
+  }&prefill_application_id=${record.id}&prefill_Name=${
+    record.fields["Name"]
+  }">form</a>, in case you need it again.</p>
+  <p>As always, don't hesitate to ask me any questions you might have!</p>
   <p>Many thanks,</p>
   <p><b>${name}</b>
   <div>Course Facilitator</div>

--- a/src/models/email/sendSurveyReminder.js
+++ b/src/models/email/sendSurveyReminder.js
@@ -1,0 +1,31 @@
+const {
+  email: { user, name }
+} = require("../../config");
+
+const transporter = require("./transporter");
+
+const sendSurveyReminder = record => {
+  const subject = "User Research reminder";
+  const html = `
+  <p>Hi,</p>
+  <p>TESTING THIS WORKS!!! HE he</p>
+  <p>Many thanks,</p>
+  <p><b>${name}</b>
+  <div>Course Facilitator</div>
+  <div>Founders & Coders</div>
+  </p>
+  `;
+  const mailOptions = {
+    from: user,
+    to: record.fields["Email"],
+    cc: user,
+    subject,
+    html
+  };
+  transporter.sendMail(mailOptions, function(err, info) {
+    if (err) console.log(err);
+    else record.updateFields({ sent_survey_reminder: true });
+  });
+};
+
+module.exports = sendSurveyReminder;


### PR DESCRIPTION
Relates #20 - the bot can now send out a reminder email to POs who haven't yet returned their user research results :tada: 

As now requested in the `README`, there's also now a USER_RESEARCH_DEADLINE environment variable in Heroku, currently set to 22nd-April (this is passed into the email template)