### PR TITLE
Update/discovery invitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Configuration is set through environment variables. The following must be set in
 
 ### Airtable Setup
 
-The fields in Airtable should be configured as per [this example](https://airtable.com/invite/l?inviteId=invjFabwJZfMFqaxf&inviteToken=79d712b468354a15d8bfc298eec154bf9bc9adc76fb59d8050617c5425563b35). Ask @charlielafosse if there are problems with access.
+The fields in Airtable should be configured as per [this example](https://airtable.com/tbl3j5Bq6SBgfJoG4/viwSi0z4zGM10Rrcp?blocks=hide). Ask @charlielafosse if there are problems with access.
 
 ## Running locally
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Configuration is set through environment variables. The following must be set in
 - GITHUB_OWNER=foundersandcoders
 - GITHUB_REPO=tech-for-better-leads // repo to create new issues in
 - GITHUB_ASSIGNEE=charlielafosse // who to assign new issues to
-- LINKS_EVENTBRITE=https://www.eventbrite.co.uk/e/tech-for-better-discovery-workshop-tickets-55336783810
+- LINKS_DISCOVERY_WORKSHOP= // URL to Discovery Workshop signup form 
 - LINKS_PO_AGREEMENT=https://docs.google.com/document/d/1PA6i2VILi4kJOF7QuJxHMwTX2dILNI2BxCBfmZ0ARHs/edit?usp=sharing
 - LINKS_RESEARCH_SURVEY_URL=YOURSURVEYLINK // URL to the follow up survey
 - LINKS_EXIT_FEEDBACK_FORM_URL=YOURFEEDBACKFORMLINK // URL to the exit feedback form

--- a/src/config.js
+++ b/src/config.js
@@ -13,7 +13,7 @@
 //GITHUB_OWNER=foundersandcoders
 //GITHUB_REPO=tech-for-better-leads
 //GITHUB_ASSIGNEE=CF's Github handle
-//LINKS_EVENTBRITE=Link to eventbrite booking page for workshop 1
+//LINKS_DISCOVERY_WORKSHOP= URL to Discovery Workshop signup form
 //LINKS_PO_AGREEMENT=Link to PO agreement on Google docs
 //LINKS_RESEARCH_SURVEY_URL=Link to follow-up research survey on Airtable
 // LINKS_EXIT_FEEDBACK_FORM_URL=Link to exit feedback form on Airtable
@@ -114,7 +114,7 @@ if (!discoverySignup)
 const productOwnerAgreementUrl = process.env.LINKS_PO_AGREEMENT
   ? process.env.LINKS_PO_AGREEMENT
   : false;
-if (!bookingUrl)
+if (!productOwnerAgreementUrl)
   throw new Error(
     "URL for Product Owner Agreement document must be set in environment variables"
   );

--- a/src/config.js
+++ b/src/config.js
@@ -109,6 +109,14 @@ if (!bookingUrl)
     "Eventbrite booking URL must be set in environment variables"
   );
 
+  const discoverySignup = process.env.LINKS_DISCOVERY_WORKSHOP
+    ? process.env.LINKS_DISCOVERY_WORKSHOP
+    : false;
+  if (!discoverySignup)
+    throw new Error(
+      "Discovery Workshop signup URL must be set in environment variables"
+    );
+
 const productOwnerAgreementUrl = process.env.LINKS_PO_AGREEMENT
   ? process.env.LINKS_PO_AGREEMENT
   : false;
@@ -140,6 +148,7 @@ module.exports = {
     bookingUrl,
     productOwnerAgreementUrl,
     researchSurveyUrl,
-    exitFeedbackFormUrl
+    exitFeedbackFormUrl,
+    discoverySignup
   }
 };

--- a/src/config.js
+++ b/src/config.js
@@ -53,10 +53,12 @@ if (!exitFeedbackFormUrl)
   );
 
 const userResearchDeadline = process.env.USER_RESEARCH_DEADLINE
- ? process.env.USER_RESEARCH_DEADLINE
- : false;
-if(!userResearchDeadline)
-  throw new Error("USER_RESEARCH_DEADLINE must be set to the current deadline for returning the results of the user research survey");
+  ? process.env.USER_RESEARCH_DEADLINE
+  : false;
+if (!userResearchDeadline)
+  throw new Error(
+    "USER_RESEARCH_DEADLINE must be set to the current deadline for returning the results of the user research survey"
+  );
 
 let pass;
 if (process.env.EMAIL_PASSWORD) {
@@ -101,21 +103,13 @@ if (!assignee) {
   throw new Error("GITHUB_TOKEN must be set in environment variables");
 }
 
-const bookingUrl = process.env.LINKS_EVENTBRITE
-  ? process.env.LINKS_EVENTBRITE
+const discoverySignup = process.env.LINKS_DISCOVERY_WORKSHOP
+  ? process.env.LINKS_DISCOVERY_WORKSHOP
   : false;
-if (!bookingUrl)
+if (!discoverySignup)
   throw new Error(
-    "Eventbrite booking URL must be set in environment variables"
+    "Discovery Workshop signup URL must be set in environment variables"
   );
-
-  const discoverySignup = process.env.LINKS_DISCOVERY_WORKSHOP
-    ? process.env.LINKS_DISCOVERY_WORKSHOP
-    : false;
-  if (!discoverySignup)
-    throw new Error(
-      "Discovery Workshop signup URL must be set in environment variables"
-    );
 
 const productOwnerAgreementUrl = process.env.LINKS_PO_AGREEMENT
   ? process.env.LINKS_PO_AGREEMENT
@@ -145,7 +139,6 @@ module.exports = {
     assignee
   },
   links: {
-    bookingUrl,
     productOwnerAgreementUrl,
     researchSurveyUrl,
     exitFeedbackFormUrl,

--- a/src/controllers/checkRecords.js
+++ b/src/controllers/checkRecords.js
@@ -58,11 +58,10 @@ const checkRecords = (req, res, next) => {
     .then(sendSurvey)
     .catch(console.error);
 
-  // Airtable formula to check for replies to the Discovery Workshop signup.
+  // Airtable formula to check for new signups for Discovery Workshop
   const newDiscoverySignup = "{table_updated} = 0";
   queryWorkshopsByFormula(newDiscoverySignup)
     .then(updateAvailableDates)
-    // write function that will update main table with possible dates, and email CF?
     .catch(console.error);
 
   // Airtable formula to check for rows in the follow-up survey table, where the results

--- a/src/controllers/checkRecords.js
+++ b/src/controllers/checkRecords.js
@@ -58,7 +58,7 @@ const checkRecords = (req, res, next) => {
     .then(sendSurvey)
     .catch(console.error);
 
-  // Airtable formula to check for new signups for Discovery Workshop
+  // Airtable formula to check for new signups for Discovery Workshops
   const newDiscoverySignup = "{table_updated} = 0";
   queryWorkshopsByFormula(newDiscoverySignup)
     .then(updateAvailableDates)

--- a/src/models/airtable/index.js
+++ b/src/models/airtable/index.js
@@ -1,11 +1,13 @@
 const {
   queryApplicationsByFormula,
   querySurveysByFormula,
+  queryWorkshopsByFormula
 } = require("./queryByFormula")
 const queryById = require("./queryById")
 
 module.exports = {
   queryApplicationsByFormula,
   querySurveysByFormula,
+  queryWorkshopsByFormula,
   queryById,
 }

--- a/src/models/airtable/queryByFormula.js
+++ b/src/models/airtable/queryByFormula.js
@@ -67,4 +67,34 @@ const querySurveysByFormula = formula => {
   })
 }
 
-module.exports = { queryApplicationsByFormula, querySurveysByFormula }
+// this can definitely be refactored and pass a template literal into base()
+
+const queryWorkshopsByFormula = formula => {
+  return new Promise((resolve, reject) => {
+    let results = []
+    base("Discovery Workshops")
+      .select({
+        maxRecords: 1200,
+        pageSize: 100,
+        view: "Grid view",
+        filterByFormula: formula,
+      })
+      .eachPage(
+        function page(records, fetchNextPage) {
+          records.forEach(record => {
+            results.push(record)
+          })
+          fetchNextPage()
+        },
+        function done(err) {
+          if (err) {
+            reject(err)
+          } else {
+            resolve(results)
+          }
+        }
+      )
+  })
+}
+
+module.exports = { queryApplicationsByFormula, querySurveysByFormula, queryWorkshopsByFormula }

--- a/src/models/email/index.js
+++ b/src/models/email/index.js
@@ -6,6 +6,7 @@ const sendFollowUpSurvey = require("./sendFollowUpSurvey");
 const sendClientSurveyNotification = require("./sendClientSurveyNotification");
 const sendExitFeedbackForm = require("./sendExitFeedbackForm");
 const sendSurveyReminder = require("./sendSurveyReminder")
+const sendCFDiscoverySignup = require("./sendCFDiscoverySignup");
 
 module.exports = {
   sendCFNotification,
@@ -15,5 +16,6 @@ module.exports = {
   sendFollowUpSurvey,
   sendClientSurveyNotification,
   sendExitFeedbackForm,
-  sendSurveyReminder
+  sendSurveyReminder,
+  sendCFDiscoverySignup
 };

--- a/src/models/email/sendCFDiscoverySignup.js
+++ b/src/models/email/sendCFDiscoverySignup.js
@@ -20,11 +20,10 @@ const sendCFDiscoverySignup = record => {
   </style>
   <h1>New Discovery Workshop Signup 🎉</h1>
   <p><b>Name:&nbsp;</b>${record.fields["Name"]}</p>
-  <p><b>Email:&nbsp;</b><a href="mailto:${record.fields["Email"]}">${
-    record.fields["Email"]
-  }</a></p>
   <p><b>Organisation:&nbsp;</b>${record.fields["Organisation"]}</p>
-  <p><b>They have said they're available for these dates:&nbsp;</b>${record.fields.discovery_workshop_dates}</p>
+  <p><b>Available for these dates:&nbsp;</b>${record.fields.discovery_workshop_dates}</p>
+  <p>Follow up with them up at&nbsp;<a href="mailto:${record.fields["Email"]}">${
+    record.fields["Email"]}</a>, and confirm a date.</p>
   `
   const mailOptions = {
     from: user,

--- a/src/models/email/sendCFDiscoverySignup.js
+++ b/src/models/email/sendCFDiscoverySignup.js
@@ -1,0 +1,41 @@
+const {
+  email: { user },
+} = require("../../config")
+
+const transporter = require("./transporter");
+
+const sendCFDiscoverySignup = record => {
+  const subject = "Discovery Workshop Signup"
+  const html = `
+  <style>
+  p {
+    max-width: 37.5em;
+  }
+  h1 {
+    font-size: 1.8rem;
+  }
+  h2 {
+    font-size: 1.4rem;
+  }
+  </style>
+  <h1>New Discovery Workshop Signup 🎉</h1>
+  <p><b>Name:&nbsp;</b>${record.fields["Name"]}</p>
+  <p><b>Email:&nbsp;</b><a href="mailto:${record.fields["Email"]}">${
+    record.fields["Email"]
+  }</a></p>
+  <p><b>Organisation:&nbsp;</b>${record.fields["Organisation"]}</p>
+  <p><b>They have said they're available for these dates:&nbsp;</b>${record.fields.discovery_workshop_dates}</p>
+  `
+  const mailOptions = {
+    from: user,
+    to: user,
+    subject,
+    html,
+  }
+  transporter.sendMail(mailOptions, function(err, info) {
+    if (err) console.error(err)
+    // else record.updateFields({ notification_sent: true })
+  })
+}
+
+module.exports = sendCFDiscoverySignup

--- a/src/models/email/sendClientInvitation.js
+++ b/src/models/email/sendClientInvitation.js
@@ -19,7 +19,7 @@ const sendClientInvitation = record => {
      record.fields["Organisation"]
    }&prefill_application_id=${record.id}&prefill_Name=${
      record.fields["Name"]
-   }">form</a>
+   }"> this form.</a>
 
   </p>
   <p>If you wish, you can bring one guest with you to our workshop - if you work as part of a team, we do ask that

--- a/src/models/email/sendClientInvitation.js
+++ b/src/models/email/sendClientInvitation.js
@@ -1,6 +1,6 @@
 const {
   email: { user, name },
-  links: { bookingUrl, productOwnerAgreementUrl },
+  links: { discoverySignup, productOwnerAgreementUrl },
 } = require("../../config")
 
 const transporter = require("./transporter")
@@ -11,7 +11,17 @@ const sendClientInvitation = record => {
   <p>Hello!</p>
   <p>We would love to invite you to take part in the Tech for Better programme! We will start with
   an introductory workshop for our developers to get to know you and the problems you want to solve</p>
-  <p>You can book a place at one of our upcoming workshops via <a href="${bookingUrl}">Eventbrite.</a></p>
+  <p>You can book a place at one of our upcoming workshops via
+
+
+
+   <a href="${discoverySignup}?prefill_Organisation=${
+     record.fields["Organisation"]
+   }&prefill_application_id=${record.id}&prefill_Name=${
+     record.fields["Name"]
+   }">form</a>
+
+  </p>
   <p>If you wish, you can bring one guest with you to our workshop - if you work as part of a team, we do ask that
   you nominate one person to act as Product Owner for the duration of the project, who should have full
   authority to make any decisions relating to the product we make with you.</p>

--- a/src/models/email/sendClientInvitationReminder.js
+++ b/src/models/email/sendClientInvitationReminder.js
@@ -1,6 +1,6 @@
 const {
   email: { user, name },
-  links: { bookingUrl, productOwnerAgreementUrl },
+  links: { discoverySignup, productOwnerAgreementUrl },
 } = require("../../config")
 
 const transporter = require("./transporter")
@@ -9,12 +9,12 @@ const sendClientInvitationReminder = record => {
   const subject = "Tech for Better"
   const html = `
   <p>Hi,</p>
-  <p>We’d still love for you to come in for a discovery workshop with us! Please take a look at our available dates 
+  <p>We’d still love for you to come in for a discovery workshop with us! Please take a look at our available dates
   and book yourself in for one.</p>
-  <p>You can bring along one guest if you like - there’s no need to book additional tickets.</p>
-  <p>Please reserve your place on our <a href="${bookingUrl}">Eventbrite booking page</a>
+  <p>You can bring along one guest if you like - there’s no need to make an additional booking.</p>
+  <p>Please reserve your place through <a href="${discoverySignup}">this form.</a>
   <p>Before your workshop, please take a look at our <a href="${productOwnerAgreementUrl}">Product Owner Agreement</a>
-   and please do let me know if you have any questions at all.</p>
+   and let me know if you have any questions at all.</p>
   <p>Thanks,</p>
   <p>
   <div><b>${name}</b></div>

--- a/src/models/email/sendClientInvitationReminder.js
+++ b/src/models/email/sendClientInvitationReminder.js
@@ -1,18 +1,22 @@
 const {
   email: { user, name },
-  links: { discoverySignup, productOwnerAgreementUrl },
-} = require("../../config")
+  links: { discoverySignup, productOwnerAgreementUrl }
+} = require("../../config");
 
-const transporter = require("./transporter")
+const transporter = require("./transporter");
 
 const sendClientInvitationReminder = record => {
-  const subject = "Tech for Better"
+  const subject = "Tech for Better";
   const html = `
   <p>Hi,</p>
   <p>We’d still love for you to come in for a discovery workshop with us! Please take a look at our available dates
   and book yourself in for one.</p>
   <p>You can bring along one guest if you like - there’s no need to make an additional booking.</p>
-  <p>Please reserve your place through <a href="${discoverySignup}">this form.</a>
+  <p>Please reserve your place through <a href="${discoverySignup}?prefill_Organisation=${
+    record.fields["Organisation"]
+  }&prefill_application_id=${record.id}&prefill_Name=${
+    record.fields["Name"]
+  }"> this form.</a>
   <p>Before your workshop, please take a look at our <a href="${productOwnerAgreementUrl}">Product Owner Agreement</a>
    and let me know if you have any questions at all.</p>
   <p>Thanks,</p>
@@ -21,18 +25,18 @@ const sendClientInvitationReminder = record => {
   <div>Course Facilitator</div>
   <div>Founders & Coders</div>
   </p>
-  `
+  `;
   const mailOptions = {
     from: user,
     to: record.fields["Email"],
     cc: user,
     subject,
-    html,
-  }
+    html
+  };
   transporter.sendMail(mailOptions, function(err, info) {
-    if (err) console.log(err)
-    else record.updateFields({ invitation_reminder_sent: true })
-  })
-}
+    if (err) console.log(err);
+    else record.updateFields({ invitation_reminder_sent: true });
+  });
+};
 
-module.exports = sendClientInvitationReminder
+module.exports = sendClientInvitationReminder;


### PR DESCRIPTION
Fixes #13 

The invitation email now links to an Airtable form which provides the organisation with a multiple select of available dates for Discovery Workshops. Once they select their dates and submit the form, the `discovery_workshop_dates` field will be updated with a joined string of the dates they can do. CF will also receive an email notification of the available dates. This has required adding a new table to the Tech for Better base: "Discovery Workshops". It works in a fairly similar way to the "User Research Survey" table, making use of a record's unique id which is passed through as `application_id`.

CF will still need to sort organisations into a confirmed workshop date and follow up with them. I couldn't find a way to update the options of a multiple select field (i.e remove a date once it's been filled up) programatically through the API :cry:. As such the CF will need to manually remove the relevant options from the `Date` field in the "Discovery Workshops" table, so that booked-out dates aren't displayed to the organisation.